### PR TITLE
Solving QueryBuilder problem when using postgresql

### DIFF
--- a/src/api/TotalRecordsController.php
+++ b/src/api/TotalRecordsController.php
@@ -135,7 +135,6 @@ class TotalRecordsController extends Controller
                         ->join($joinInformation['joinTable'], $joinInformation['joinColumnFirst'], $joinInformation['joinEqual'], $joinInformation['joinColumnSecond']);
                 } else {
                     if($connectionName == 'pgsql'){
-                        //$query = $model::selectRaw('HOUR('.$xAxisColumn.') AS cat, HOUR('.$xAxisColumn.') AS catorder, sum('.$calculation.') counted'.$seriesSql);
                         $query = $model::selectRaw("to_char(DATE_TRUNC('hour', ".$xAxisColumn."), 'HH24:MI:SS') AS cat, to_char(DATE_TRUNC('hour', ".$xAxisColumn."), 'HH24:MI:SS') AS catorder, sum(".$calculation.") counted".$seriesSql);
 
                     }

--- a/src/api/TotalRecordsController.php
+++ b/src/api/TotalRecordsController.php
@@ -63,7 +63,7 @@ class TotalRecordsController extends Controller
                         }
                         $seriesSql .= "then ".$calculation." else 0 end) as '".$labelList[$seriesKey]."'";
                     } else {
-                        $seriesSql .= ", SUM(CASE WHEN ".$filter->key." ".($filter->operator ?? "=")." '".$filter->value."' then ".$calculation." else 0 end) as '".$labelList[$seriesKey]."'";
+                        $seriesSql .= ", SUM(CASE WHEN ".$filter->key." ".($filter->operator ?? "=")." '".$filter->value."' then ".$calculation." else 0 end) as \"".$labelList[$seriesKey]."\"";
                     }
                 }
             }
@@ -134,7 +134,15 @@ class TotalRecordsController extends Controller
                     $query = $model::selectRaw('HOUR('.$xAxisColumn.') AS cat, HOUR('.$xAxisColumn.') AS catorder, sum('.$calculation.') counted'.$seriesSql)
                         ->join($joinInformation['joinTable'], $joinInformation['joinColumnFirst'], $joinInformation['joinEqual'], $joinInformation['joinColumnSecond']);
                 } else {
-                    $query = $model::selectRaw('HOUR('.$xAxisColumn.') AS cat, HOUR('.$xAxisColumn.') AS catorder, sum('.$calculation.') counted'.$seriesSql);
+                    if($connectionName == 'pgsql'){
+                        //$query = $model::selectRaw('HOUR('.$xAxisColumn.') AS cat, HOUR('.$xAxisColumn.') AS catorder, sum('.$calculation.') counted'.$seriesSql);
+                        $query = $model::selectRaw("to_char(DATE_TRUNC('hour', ".$xAxisColumn."), 'HH24:MI:SS') AS cat, to_char(DATE_TRUNC('hour', ".$xAxisColumn."), 'HH24:MI:SS') AS catorder, sum(".$calculation.") counted".$seriesSql);
+
+                    }
+                    else{
+                        $query = $model::selectRaw('HOUR('.$xAxisColumn.') AS cat, HOUR('.$xAxisColumn.') AS catorder, sum('.$calculation.') counted'.$seriesSql);
+                
+                    }
                 }
 
                 if(is_numeric($advanceFilterSelected)){


### PR DESCRIPTION
The problem occurs when a querybuilder is assembled for postgresql, since part of the code was dependent on Mysql, added some changes were made so that it accepts both MySQL and PostgreSQL.